### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,50 @@
+# Claude
+.claude/
+CLAUDE.md
+
+# IntelliJ IDEA
+.idea/
+*.iml
+*.iws
+*.ipr
+out/
+.idea_modules/
+
+# Build
+build/
+target/
+dist/
+*.class
+*.jar
+*.war
+*.ear
+
+# Gradle
+.gradle/
+gradle-app.setting
+!gradle-wrapper.jar
+!gradle-wrapper.properties
+
+# Maven
+.mvn/
+mvnw
+mvnw.cmd
+
+# OS
+.DS_Store
+Thumbs.db
+desktop.ini
+
+# Logs
+*.log
+logs/
+
+# Env
+.env
+.env.local
+*.local
+
+# Temp
+*.tmp
+*.swp
+*.bak


### PR DESCRIPTION
## Summary
- Add `.gitignore` covering Claude, IntelliJ IDEA, build outputs (Gradle/Maven), OS junk, logs, env files, and temp files.

Refs #1

## Test plan
- [x] `git status` is clean after IDEA opens the project (no `.idea/`, `*.iml`, `out/` showing up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)