### PR TITLE
CI: build project on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: yapi
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew build


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build.yml` that runs on every PR against `main`.
- Sets up Temurin JDK 21 and uses `gradle/actions/setup-gradle@v4` for dependency caching.
- Runs `./gradlew build` against the Gradle root in `yapi/`; failure blocks the PR check.

## Test plan
- [ ] Confirm the `Build` check appears and passes on this PR.
- [ ] Verify subsequent runs reuse the Gradle cache.

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)